### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/scripts/demo.cjs
+++ b/scripts/demo.cjs
@@ -16,15 +16,32 @@ const mimeTypes = {
 
 const server = http.createServer((req, res) => {
 	const urlPath = req.url === "/" ? "/demo/index.html" : req.url.split("?")[0];
-	const filePath = path.join(root, decodeURIComponent(urlPath));
+	let decodedPath;
+	try {
+		decodedPath = decodeURIComponent(urlPath);
+	} catch {
+		res.writeHead(400, { "Content-Type": "text/plain" });
+		return res.end("Bad request");
+	}
 
-	fs.readFile(filePath, (err, data) => {
+	const resolvedPath = path.resolve(root, `.${decodedPath}`);
+	const relativePath = path.relative(root, resolvedPath);
+	if (
+		relativePath.startsWith("..") ||
+		path.isAbsolute(relativePath) ||
+		decodedPath.includes("\0")
+	) {
+		res.writeHead(403, { "Content-Type": "text/plain" });
+		return res.end("Forbidden");
+	}
+
+	fs.readFile(resolvedPath, (err, data) => {
 		if (err) {
 			res.writeHead(404, { "Content-Type": "text/plain" });
 			return res.end("Not found");
 		}
 
-		const ext = path.extname(filePath).toLowerCase();
+		const ext = path.extname(resolvedPath).toLowerCase();
 		res.writeHead(200, { "Content-Type": mimeTypes[ext] || "text/plain" });
 		res.end(data);
 	});


### PR DESCRIPTION
Potential fix for [https://github.com/printf83/bsts/security/code-scanning/1](https://github.com/printf83/bsts/security/code-scanning/1)

Use a safe-root validation flow before calling `fs.readFile`:

1. Parse the request path safely.
2. Decode in a `try/catch` (invalid encodings should return 400).
3. Resolve an absolute path with `path.resolve(root, "." + decodedPath)` (the `"."` forces relative treatment).
4. Verify containment with `path.relative(root, resolvedPath)` and reject if it escapes (`..`), is absolute, or includes null bytes.
5. Use the validated resolved path for both `readFile` and extension lookup.

In `scripts/demo.cjs`, replace the current `urlPath/filePath` construction and `fs.readFile(filePath...)` usage with validated `resolvedPath` logic and early 400/403 responses. No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
